### PR TITLE
Added namespace column to list repositories which are not owned by the authenticated user

### DIFF
--- a/dockerhub/table_dockerhub_repository.go
+++ b/dockerhub/table_dockerhub_repository.go
@@ -2,6 +2,7 @@ package dockerhub
 
 import (
 	"context"
+	"github.com/docker/hub-tool/pkg/hub"
 	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
 	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
 	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
@@ -24,7 +25,7 @@ func tableDockerHubRepository(_ context.Context) *plugin.Table {
 				Name:        "namespace",
 				Type:        proto.ColumnType_STRING,
 				Description: "Namespace of the repository.",
-				Transform:   transform.FromQual("namespace"),
+				Transform:   transform.From(fetchNamespaceFromRepository),
 			},
 			{
 				Name:        "name",
@@ -117,4 +118,10 @@ func getNamespace(ctx context.Context, d *plugin.QueryData) (string, error) {
 	}
 
 	return user.Name, nil
+}
+
+func fetchNamespaceFromRepository(_ context.Context, d *transform.TransformData) (interface{}, error) {
+	repository := d.HydrateItem.(hub.Repository)
+	namespace, _ := splitRepositoryName(repository.Name)
+	return namespace, nil
 }

--- a/dockerhub/table_dockerhub_tag.go
+++ b/dockerhub/table_dockerhub_tag.go
@@ -2,7 +2,6 @@ package dockerhub
 
 import (
 	"context"
-
 	"github.com/docker/hub-tool/pkg/hub"
 	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
 	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
@@ -27,7 +26,7 @@ func tableDockerHubTag(_ context.Context) *plugin.Table {
 				Name:        "namespace",
 				Type:        proto.ColumnType_STRING,
 				Description: "Namespace of the repository.",
-				Transform:   transform.FromQual("namespace"),
+				Transform:   transform.From(fetchNamespaceFromTag),
 			},
 			{
 				Name:        "name",
@@ -106,4 +105,10 @@ func listTags(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (
 	}
 
 	return nil, nil
+}
+
+func fetchNamespaceFromTag(_ context.Context, d *transform.TransformData) (interface{}, error) {
+	tag := d.HydrateItem.(hub.Tag)
+	namespace, _ := splitRepositoryName(tag.Name)
+	return namespace, nil
 }

--- a/dockerhub/table_dockerhub_tag.go
+++ b/dockerhub/table_dockerhub_tag.go
@@ -18,8 +18,17 @@ func tableDockerHubTag(_ context.Context) *plugin.Table {
 		List: &plugin.ListConfig{
 			ParentHydrate: listRepositories,
 			Hydrate:       listTags,
+			KeyColumns: []*plugin.KeyColumn{
+				{Name: "namespace", Require: plugin.Optional, Operators: []string{"="}},
+			},
 		},
 		Columns: commonColumns([]*plugin.Column{
+			{
+				Name:        "namespace",
+				Type:        proto.ColumnType_STRING,
+				Description: "Namespace of the repository.",
+				Transform:   transform.FromQual("namespace"),
+			},
 			{
 				Name:        "name",
 				Type:        proto.ColumnType_STRING,

--- a/dockerhub/utils.go
+++ b/dockerhub/utils.go
@@ -3,10 +3,10 @@ package dockerhub
 import (
 	"context"
 	"errors"
-	"os"
-
 	"github.com/docker/hub-tool/pkg/hub"
 	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
+	"os"
+	"strings"
 )
 
 func getClient(ctx context.Context, d *plugin.QueryData) (*hub.Client, error) {
@@ -90,4 +90,14 @@ func GetUserInfoUncached(ctx context.Context, d *plugin.QueryData, _ *plugin.Hyd
 	}
 
 	return user, nil
+}
+
+// split the repository name into namespace and repository name
+func splitRepositoryName(repository string) (string, string) {
+	parts := strings.Split(repository, "/")
+	if len(parts) > 1 {
+		return parts[0], parts[1]
+	}
+
+	return "", repository
 }

--- a/docs/tables/dockerhub_repository.md
+++ b/docs/tables/dockerhub_repository.md
@@ -11,6 +11,10 @@ DockerHub is a cloud-based registry service that allows you to link to code repo
 
 The `dockerhub_repository` table provides insights into repositories within DockerHub. As a DevOps engineer, explore repository-specific details through this table, including repository name, description, star count, pull count, and last updated date. Utilize it to uncover information about repositories, such as those with high pull counts, the most starred repositories, and recently updated repositories.
 
+## Specify a namespace
+
+The `namespace` column in the `dockerhub_repository` table represents the repository namespace. By default, the namespace is set to the name of the authenticated user. To query repositories in a different namespace (e.g. `turbot` or `library`), you can specify the namespace in the `where` clause.
+
 ## Examples
 
 ### Basic info
@@ -65,6 +69,35 @@ from
   dockerhub_repository
 where
   is_private = 1;
+```
+
+### List public repositories owned by a different account
+Explore public repositories on DockerHub which are not owned by the authenticated user and can be accessed by anyone. This query can help you get detailed information about public repositories in a specific namespace.
+
+```sql+postgres
+select
+  name,
+  pull_count,
+  star_count,
+  is_private,
+  last_updated
+from
+  dockerhub_repository
+where
+  namespace = 'turbot';
+```
+
+```sql+sqlite
+select
+  name,
+  pull_count,
+  star_count,
+  is_private,
+  last_updated
+from
+  dockerhub_repository
+where
+  namespace = 'turbot';
 ```
 
 ### List repositories with no pulls or downloads

--- a/docs/tables/dockerhub_tag.md
+++ b/docs/tables/dockerhub_tag.md
@@ -11,6 +11,10 @@ DockerHub is a cloud-based registry service that allows you to link to code repo
 
 The `dockerhub_tag` table provides insights into the tags within DockerHub repositories. As a DevOps engineer, you can explore tag-specific details through this table, including the associated DockerHub repository, the tag name, and its manifest. Utilize this table to manage and monitor your DockerHub repositories, ensuring that all tags are up-to-date and follow your organization's naming conventions.
 
+## Specify a namespace
+
+The `namespace` column in the `dockerhub_tag` table represents the repository namespace. By default, the namespace is set to the name of the authenticated user. To query tags in a different namespace (e.g. `turbot` or `library`), you can specify the namespace in the `where` clause.
+
 ## Examples
 
 ### Basic info
@@ -69,6 +73,39 @@ from
   dockerhub_tag
 where
   name like 'souravthe/test%';
+```
+
+### List tags which are from a particular repository owned by a different account
+Discover the segments that are from a specific repository, allowing you to analyze the status, last update, and size of these segments. This can be useful to get detailed information about public repositories in a specific namespace.
+
+```sql+postgres
+select
+  name,
+  status,
+  last_updater_user_name,
+  last_pushed,
+  last_pulled,
+  full_size
+from
+  dockerhub_tag
+where
+  namespace = 'turbot'
+  and name like 'turbot/steampipe:0.21%';
+```
+
+```sql+sqlite
+select
+  name,
+  status,
+  last_updater_user_name,
+  last_pushed,
+  last_pulled,
+  full_size
+from
+  dockerhub_tag
+where
+  namespace = 'turbot'
+  and name like 'turbot/steampipe:0.21%';
 ```
 
 ### List tags with no pulls or downloads


### PR DESCRIPTION
Fixes #24 

# Example query results
<details>
  <summary>Results</summary>

```
# dockerhub_repository

> select
    namespace,
    name,
    pull_count,
    star_count,
    is_private,
    last_updated
from
    dockerhub_repository
where namespace = 'turbot';
+-----------+------------------+------------+------------+------------+---------------------------+
| namespace | name             | pull_count | star_count | is_private | last_updated              |
+-----------+------------------+------------+------------+------------+---------------------------+
| turbot    | turbot/steampipe | 102984     | 6          | false      | 2024-03-15T11:24:26+01:00 |
+-----------+------------------+------------+------------+------------+---------------------------+

> select
    namespace,
    name,
    pull_count,
    star_count,
    is_private,
    last_updated
from 
    dockerhub_repository;
+----------------+---------------------+------------+------------+------------+---------------------------+
| namespace      | name                | pull_count | star_count | is_private | last_updated              |
+----------------+---------------------+------------+------------+------------+---------------------------+
| hebestreit     | hebestreit/nginx    | <null>     | <null>     | true       | 2024-09-04T09:33:10+02:00 |
+----------------+---------------------+------------+------------+------------+---------------------------+

# dockerhub_tag

> select
    namespace,
    name,
    status,
    last_updater_user_name,
    last_pushed,
    last_pulled,
    full_size
from
    dockerhub_tag
where
    namespace = 'turbot'
  and name like 'turbot/steampipe:0.21%';
+-----------+-------------------------+----------+------------------------+---------------------------+---------------------------+-----------+
| namespace | name                    | status   | last_updater_user_name | last_pushed               | last_pulled               | full_size |
+-----------+-------------------------+----------+------------------------+---------------------------+---------------------------+-----------+
| turbot    | turbot/steampipe:0.21.5 | inactive | kaidaguerre            | 2024-02-05T18:57:41+01:00 | 2024-06-25T20:23:15+02:00 | 103245158 |
| turbot    | turbot/steampipe:0.21.7 | active   | kaidaguerre            | 2024-02-09T18:01:01+01:00 | 2024-09-04T03:45:16+02:00 | 103073197 |
| turbot    | turbot/steampipe:0.21.3 | inactive | kaidaguerre            | 2024-01-05T16:24:00+01:00 | 2024-06-03T11:57:34+02:00 | 103435655 |
| turbot    | turbot/steampipe:0.21.1 | inactive | kaidaguerre            | 2023-10-03T17:11:26+02:00 | 2024-07-30T06:16:38+02:00 | 117339696 |
| turbot    | turbot/steampipe:0.21.4 | active   | kaidaguerre            | 2024-01-23T13:28:51+01:00 | 2024-09-04T00:07:09+02:00 | 103435639 |
| turbot    | turbot/steampipe:0.21.2 | inactive | kaidaguerre            | 2023-12-12T16:31:11+01:00 | 2024-07-30T06:09:34+02:00 | 103223967 |
| turbot    | turbot/steampipe:0.21.0 | active   | kaidaguerre            | 2023-10-02T13:41:30+02:00 | 2024-09-03T09:20:42+02:00 | 117338375 |
| turbot    | turbot/steampipe:0.21.6 | active   | kaidaguerre            | 2024-02-06T13:33:56+01:00 | 2024-08-25T02:00:05+02:00 | 103245103 |
| turbot    | turbot/steampipe:0.21.8 | inactive | kaidaguerre            | 2024-02-23T15:36:00+01:00 | 2024-07-30T06:16:17+02:00 | 103282153 |
+-----------+-------------------------+----------+------------------------+---------------------------+---------------------------+-----------+

> select
    namespace,
    name,
    status,
    last_updater_user_name,
    last_pushed,
    last_pulled,
    full_size
from
    dockerhub_tag;
+----------------+--------------------------+--------+------------------------+---------------------------+-------------+-----------+
| namespace      | name                     | status | last_updater_user_name | last_pushed               | last_pulled | full_size |
+----------------+--------------------------+--------+------------------------+---------------------------+-------------+-----------+
| hebestreit     | hebestreit/nginx:1.27    | active | hebestreit             | 2024-09-04T09:33:09+02:00 | <null>      | 67670094  |
+----------------+--------------------------+--------+------------------------+---------------------------+-------------+-----------+

```
</details>
